### PR TITLE
IP-62731:  Make UriUtility public

### DIFF
--- a/src/Intelliflo.SDK.Security/Utils/UriUtility.cs
+++ b/src/Intelliflo.SDK.Security/Utils/UriUtility.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Intelliflo.SDK.Security.Utils
 {
-    internal static class UriUtility
+    public static class UriUtility
     {
         internal static string GetQuery(this Uri uri)
         {


### PR DESCRIPTION
<!--- Mandatory -->
##### CHANGE TYPE
<!--- Pick one below and delete the rest: -->
 - Patch

https://tickets.intelliflo.com/browse/IP-62731
<!--- Optional - Must complete if Minor or Major change, else delete section-->

##### DESIGN CONSIDERATIONS AND RATIONALE
In order to have consistent Uri encoding everywhere, the utility class UriUtility made public.

<!--- Mandatory -->
##### IMPACT, DEPENDENCIES AND TEST CONSIDERATIONS

This change should not affect any areas.